### PR TITLE
Fix slack notification

### DIFF
--- a/.github/workflows/broken-link-checks.yml
+++ b/.github/workflows/broken-link-checks.yml
@@ -14,7 +14,7 @@ jobs:
           url: https://boxyhq.com
           cmd_params: '--buffer-size=8192 --max-connections=10 --color=always --exclude="(localhost|127.0.0.1|twitter.com|linkedin.com|manage.auth0.com|schemas.xmlsoap.org)" --skip-tls-verification'
       - name: Post to Slack
-        if: ${{ job.status == 'failure' }}
+        if: ${{ failure() }}
         uses: slackapi/slack-github-action@v1.18.0
         with:
           # Slack channel id, channel name, or user id to post message.


### PR DESCRIPTION
This should fix a bug where the slack notification step was not running. Using [failure()](https://docs.github.com/en/actions/learn-github-actions/expressions#failure) to check if previous step failed instead of the job status.