### PR TITLE
Fix the Guide and Docs overview page UI on mobile devices

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,7 +12,7 @@ BoxyHQ helps startups enable enterprise features in any SaaS app with just a few
 
 <div className="container" style={{ padding: 0 }}>
   <div className="row is-multiline">
-    <div className="col col--6">
+    <div className="col col--6 margin-bottom--sm">
       <Link
         className="card"
         to="/docs/jackson/overview"
@@ -27,7 +27,7 @@ BoxyHQ helps startups enable enterprise features in any SaaS app with just a few
         </div>
       </Link>
     </div>
-    <div className="col col--6">
+    <div className="col col--6 margin-bottom--sm">
       <Link
         className="card"
         to="/docs/directory-sync/overview"

--- a/guides/index.mdx
+++ b/guides/index.mdx
@@ -12,7 +12,7 @@ BoxyHQ helps startups enable enterprise features in any SaaS app with just a few
 
 <div className="container" style={{ padding: 0 }}>
   <div className="row is-multiline">
-    <div className="col col--6">
+    <div className="col col--6 margin-bottom--sm">
       <Link className="card" to="/guides/jackson" style={{ height: '100%' }}>
         <div className="card__body">
           <h4>SAML Jackson</h4>
@@ -23,12 +23,17 @@ BoxyHQ helps startups enable enterprise features in any SaaS app with just a few
         </div>
       </Link>
     </div>
-    <div className="col col--6">
-      <Link className="card" to="/guides/directory-sync" style={{ height: '100%' }}>
+    <div className="col col--6 margin-bottom--sm">
+      <Link
+        className="card"
+        to="/guides/directory-sync"
+        style={{ height: '100%' }}
+      >
         <div className="card__body">
           <h4>Directory Sync (SCIM 2.0)</h4>
           <p>
-            Directory Sync service that helps organizations automate the provisioning and de-provisioning of their users.
+            Directory Sync service that helps organizations automate the
+            provisioning and de-provisioning of their users.
           </p>
         </div>
       </Link>

--- a/src/components/GuideSection.js
+++ b/src/components/GuideSection.js
@@ -6,7 +6,7 @@ export default function GuideSection({ items }) {
   return (
     <>
       {items.map((item) => (
-        <div key={item.name} className="col col--3">
+        <div key={item.name} className="col col--3 margin-bottom--sm">
           <Link className="card" to={item.href}>
             <div
               className="card__body"


### PR DESCRIPTION
Add the bottom padding to the cards in the Guide and Docs overview page to fix the issue on mobile devices