### PR TITLE
chore: add open position to careers and detail page

### DIFF
--- a/src/css/atoms/typography.css
+++ b/src/css/atoms/typography.css
@@ -48,7 +48,7 @@
   font-size: var(--typography-size-small-medium);
 }
 
-.marketing-site .linear-gradient-text {
+.linear-gradient-text {
   background: var(--typography-linear-gradient);
   background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/src/pages/careers/careers.css
+++ b/src/pages/careers/careers.css
@@ -5,3 +5,39 @@
 .content-wrapper {
   margin-top: var(--spacing-default);
 }
+
+.content-wrapper > p {
+  max-width: 100ch;
+}
+
+.reset-list.open-roles {
+  margin-bottom: var(--spacing-wide);
+}
+
+.open-roles .role {
+  background-color: var(--color-teal-05);
+  border: 0.1rem solid var(--color-teal-80);
+  border-radius: var(--border-radius-default);
+  padding: var(--spacing-default);
+}
+
+@media only screen and (min-width: 63.9375rem) {
+  .open-roles .role {
+    max-width: 65%;
+  }
+}
+
+@media only screen and (min-width: 83.6875rem) {
+  .open-roles .role {
+    max-width: 45%;
+  }
+}
+
+.open-roles .role a {
+  font-size: var(--typography-size-small-medium);
+}
+
+.open-roles .role a:hover,
+.open-roles .role a:focus {
+  text-decoration: none;
+}

--- a/src/pages/careers/careers.css
+++ b/src/pages/careers/careers.css
@@ -33,11 +33,19 @@
   }
 }
 
-.open-roles .role a {
+.role-footer-links {
+  align-items: center;
+  display: flex;
+  gap: var(--spacing-default);
+}
+
+.open-roles .role a:link,
+.open-roles .role a:visited {
   font-size: var(--typography-size-small-medium);
+  text-decoration: none;
 }
 
 .open-roles .role a:hover,
 .open-roles .role a:focus {
-  text-decoration: none;
+  text-decoration: underline;
 }

--- a/src/pages/careers/index.js
+++ b/src/pages/careers/index.js
@@ -42,7 +42,16 @@ const Careers = () => {
                 about open-source projects, security, and developer tools, we
                 want to hear from you!
               </p>
-              <a href="/careers/senior-software-engineer">Apply Today</a>
+              <ul className="reset-list role-footer-links">
+                <li>
+                  <a href="/careers/senior-software-engineer">
+                    Learn more &raquo;
+                  </a>
+                </li>
+                <li>
+                  <a href="mailto:careers@boxyhq.com">Apply today &raquo;</a>
+                </li>
+              </ul>
             </li>
           </ul>
         </div>

--- a/src/pages/careers/index.js
+++ b/src/pages/careers/index.js
@@ -19,17 +19,32 @@ const Careers = () => {
         <div className="content-wrapper">
           <h2>Career Opportunities</h2>
           <p>
-            Thank you for your interest in a career at BoxyHQ! While we
-            currently don't have any open positions, we're always on the lookout
-            for talented individuals to join our team. Our needs are constantly
-            evolving, and new opportunities can arise at any time.
+            Thank you for considering a career with BoxyHQ! We're excited about
+            your interest in joining our dynamic team. Below, you'll find a list
+            of all the current open positions within our company. At BoxyHQ,
+            we're dedicated to fostering an inclusive, innovative, and
+            supportive work environment that encourages growth and development.
+            Whether you're passionate about software development, marketing,
+            sales, or customer support, we believe there's a place for you here.
           </p>
-          <p>
-            We encourage you to check our careers page regularly for updates and
-            new job postings. If you're passionate about shaping the future of
-            enterprise software and thrive in innovative environments, we would
-            love to hear from you in the future.
-          </p>
+
+          <ul className="reset-list open-roles">
+            <li className="role">
+              <h3>
+                Senior Software Engineer - Open Source, Security, Dev Tools
+              </h3>
+              <p>
+                Join BoxyHQ as a Senior Software Engineer and lead the charge in
+                building developer-first security tools to streamline compliance
+                and enhance data security. With a focus on innovation and
+                collaboration, you'll play a pivotal role in shaping our
+                products and driving our mission forward. If you're passionate
+                about open-source projects, security, and developer tools, we
+                want to hear from you!
+              </p>
+              <a href="/careers/senior-software-engineer">Apply Today</a>
+            </li>
+          </ul>
         </div>
       </main>
     </Layout>

--- a/src/pages/careers/senior-software-engineer/index.js
+++ b/src/pages/careers/senior-software-engineer/index.js
@@ -1,0 +1,182 @@
+import Layout from '@theme/Layout';
+
+import './job-post.css';
+
+const SeniorSoftwareEngineer = () => {
+  const metaDescription =
+    "Are you a senior software engineer interested in working in the open source security space? Join BoxyHQ's team and shape the future of enterprise software security.";
+  const metaPageTitle =
+    'Senior Software Engineer - Open Source, Security, Dev Tools';
+
+  return (
+    <Layout title={metaPageTitle} description={metaDescription}>
+      <main className="girdle role-details">
+        <p>
+          <a className="role-details-backlink" href="/careers">
+            &laquo; All careers
+          </a>
+        </p>
+        <h1 className="role-primary-heading linear-gradient-text">
+          Senior Software Engineer - Open Source, Security, Dev Tools
+        </h1>
+        <div className="role-lead">
+          <p>
+            BoxyHQ [Security Building Blocks for Developers] is a commercial
+            open-source company providing APIs for security, privacy, and
+            enterprise compliance. We empower developers to automate product
+            security and enhance their SaaS applications with enterprise-ready
+            features like Single Sign-On (SSO).
+          </p>
+          <p>
+            We're seeking a highly skilled and experienced Senior Software
+            Developer to join our dynamic team. In this role, you will lead the
+            development of our open-source projects, contribute to our suite of
+            developer tools, and drive initiatives to enhance security across
+            all aspects of our products.
+          </p>
+        </div>
+
+        <h2>What You'll Be Doing:</h2>
+        <p>
+          As a Senior Software Engineer at BoxyHQ, you'll be at the forefront of
+          developing open-source API-driven developer tools that empower
+          startups to streamline compliance and enhance data security in their
+          products. Here's an overview of your responsibilities:
+        </p>
+
+        <ul>
+          <li>
+            Lead the development of our open-source API-driven developer tools,
+            ensuring high-quality code and adherence to best practices.
+          </li>
+          <li>
+            Collaborate with cross-functional teams to design and implement
+            innovative solutions to simplify compliance and data
+            security-related features.
+          </li>
+          <li>
+            Contribute to product discussions and planning openly via GitHub,
+            and actively participate in shaping our internal processes.
+          </li>
+          <li>
+            Take ownership of technical documentation, ensuring accuracy and
+            relevance to our products.
+          </li>
+          <li>
+            Share your knowledge and insights with the team and the broader
+            developer community through technical blogs, talks, and other
+            activities.
+          </li>
+          <li>
+            Take overall ownership and responsibility for the development,
+            maintenance, incident management, and security of our products and
+            systems.
+          </li>
+        </ul>
+
+        <h2>Key Skills:</h2>
+        <p>To thrive in this role, we're looking for candidates with:</p>
+        <ul>
+          <li>
+            Strong software engineering background, with experience in languages
+            like Go and JavaScript, preferred.
+          </li>
+          <li>
+            Proficiency in coding standards, unit testing, and documentation
+            practices.
+          </li>
+          <li>
+            Demonstrated ability to work effectively in a remote-first
+            environment, with a high level of self-discipline and autonomy.
+          </li>
+          <li>
+            Excellent communication skills, with the ability to engage in clear,
+            constructive, and respectful dialogue with team members and the
+            community.
+          </li>
+          <li>
+            A passion for open-source software and a commitment to driving
+            innovation in the developer tools space.
+          </li>
+          <li>
+            Ideal experience in Cybersecurity, Authentication, Authorization,
+            and/or Data Protection.
+          </li>
+          <li>A self-driven and developer-first mentality.</li>
+          <li>Native-level fluency in English.</li>
+        </ul>
+
+        <p>
+          Don't worry if you're not already well-versed in our product
+          knowledge; we'll kick off by addressing your questions and discussing
+          scenarios to ensure a seamless transition into your role.
+        </p>
+        <p>
+          <b>The ideal candidate</b> for the Senior Software Engineer role is a
+          seasoned developer with a passion for open-source projects, security,
+          and developer tools. With strong coding skills and experience in
+          languages like Go and JavaScript, you'll thrive in our dynamic,
+          remote-first environment. If you're committed to driving innovation in
+          the developer community and eager to shape the future of BoxyHQ, we
+          want to hear from you!
+        </p>
+        <h3>Schedule</h3>
+        <p>This is a full-time position (approximately 40 hours/week).</p>
+
+        <h3>Timezone</h3>
+        <p>
+          The team is 100% remote. Those who will be working with you most
+          closely are in the European & Indian time zones. But you could be
+          based anywhere in the world.
+        </p>
+
+        <h3>Perks</h3>
+        <ul>
+          <li>100% remote work environment</li>
+          <li>Flexible hours</li>
+          <li>Competitive salary</li>
+          <li>20 days of paid vacation per year</li>
+          <li>Weekly virtual hangouts with the team</li>
+          <li>Team-first, sensible working environment</li>
+        </ul>
+
+        <h3>About Us</h3>
+        <ul>
+          <li>
+            Open source-first company - your work will be visible and you will
+            be able to influence hundreds of developers!
+          </li>
+          <li>Our team is distributed remotely worldwide.</li>
+          <li>
+            BoxyHQ is still small with less than 10 employees. You will be one
+            of the first employees and can drive major parts of the product.
+          </li>
+          <li>Highly competitive salary and stock options.</li>
+          <li>
+            Experienced founders with strong engineering, commercial, and
+            open-source experience.
+          </li>
+          <li>
+            We encourage and support the team in attending conferences, giving
+            talks, writing blog posts, and other activities.
+          </li>
+          <li>
+            We believe in constantly iterating and improving; you will get to
+            influence our internal processes as well.
+          </li>
+        </ul>
+
+        <h3>How To Apply</h3>
+        <p>
+          To get started, please send your CV to{' '}
+          <a href="mailto:careers@boxyhq.com">careers@boxyhq.com</a>. We
+          encourage you to apply even if you don't feel like you match the
+          description 100%. Many great people tend to undervalue their skills,
+          so we don't want to miss the chance of meeting you.
+        </p>
+      </main>
+    </Layout>
+  );
+};
+
+export default SeniorSoftwareEngineer;

--- a/src/pages/careers/senior-software-engineer/index.js
+++ b/src/pages/careers/senior-software-engineer/index.js
@@ -40,7 +40,7 @@ const SeniorSoftwareEngineer = () => {
         <p>
           As a Senior Software Engineer at BoxyHQ, you'll be at the forefront of
           developing open-source API-driven developer tools that empower
-          startups to streamline compliance and enhance data security in their
+          companies to streamline compliance and enhance data security in their
           products. Here's an overview of your responsibilities:
         </p>
 

--- a/src/pages/careers/senior-software-engineer/job-post.css
+++ b/src/pages/careers/senior-software-engineer/job-post.css
@@ -1,0 +1,45 @@
+.girdle.role-details {
+  margin: var(--spacing-medium) auto;
+  padding: var(--spacing-medium);
+}
+
+@media only screen and (min-width: 63.9375rem) {
+  .girdle.role-details {
+    margin: var(--spacing-wide) auto;
+  }
+}
+
+.role-details h1 {
+  font-size: var(--typography-size-xl);
+}
+
+@media only screen and (min-width: 83.6875rem) {
+  .role-details h1 {
+    font-size: var(--typography-size-xxl);
+  }
+}
+
+.role-details h2 {
+  font-size: var(--typography-size-large);
+}
+
+.role-details h3 {
+  font-size: var(--typography-size-medium);
+}
+
+.role-details p {
+  max-width: 100ch;
+}
+
+.role-lead p {
+  font-size: var(--typography-size-small-medium);
+}
+
+.role-details li {
+  margin-bottom: var(--spacing-narrow);
+  max-width: 80ch;
+}
+
+.role-details-backlink {
+  font-size: var(--typography-size-small-medium);
+}


### PR DESCRIPTION
Add open role to careers page and add a detail page for the position. Once we have multiple roles that change and needs to be maintained frequently, we can move this to Markdown files.