### PR TITLE
Replace existing search with pagefind + canary

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -288,6 +288,28 @@ module.exports = {
       },
     ],
   ],
+  themes: [
+    [
+      // https://getcanary.dev/docs/local/integrations/docusaurus#configuration
+      require.resolve('@getcanary/docusaurus-theme-search-pagefind'),
+      {
+        styles: {
+          '--canary-color-primary-c': 0.015,
+          '--canary-color-primary-h': 200,
+        },
+        includeRoutes: [
+          '**/docs/**',
+          '**/blog/**',
+          '**/guides/**',
+          '**/success-stories/**',
+        ],
+        tabs: [
+          { name: 'Docs', pattern: '**/{docs,guides}/**' },
+          { name: 'Articles', pattern: '**/{blog,success-stories}/**' },
+        ],
+      },
+    ],
+  ],
   plugins: [
     [
       require.resolve('docusaurus-gtm-plugin'),
@@ -325,7 +347,6 @@ module.exports = {
         archiveBasePath: null,
       },
     ],
-    ['@easyops-cn/docusaurus-search-local', {}],
     require.resolve('docusaurus-plugin-image-zoom'),
     [
       '@docusaurus/plugin-client-redirects',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@docusaurus/plugin-client-redirects": "3.5.2",
         "@docusaurus/preset-classic": "3.5.2",
         "@easyops-cn/docusaurus-search-local": "0.45.0",
+        "@getcanary/docusaurus-theme-search-pagefind": "^1.0.2",
+        "@getcanary/web": "^1.0.10",
         "@mdx-js/react": "3.0.1",
         "@scalar/docusaurus": "0.4.115",
         "clsx": "2.1.1",
@@ -3234,6 +3236,51 @@
         }
       }
     },
+    "node_modules/@getcanary/docusaurus-theme-search-pagefind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@getcanary/docusaurus-theme-search-pagefind/-/docusaurus-theme-search-pagefind-1.0.2.tgz",
+      "integrity": "sha512-DNXfzBJ8ooJdWvEjI+63Al6ywUmpaDFxJBIyDX+Lh95+0wEocpzfaFfDMP/5YVRYm8ZRCUAQwSZgKsRCQ5Ar7Q==",
+      "dependencies": {
+        "@getcanary/web": "^1.0.0",
+        "cli-progress": "^3.12.0",
+        "micromatch": "^4.0.7",
+        "pagefind": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^2.0.0 || ^3.0.0",
+        "@getcanary/web": "^1.0.0",
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@getcanary/web": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@getcanary/web/-/web-1.0.10.tgz",
+      "integrity": "sha512-gkOyjU0K/xS+rxDxHDS7lOOFKK79g+fwuB2iB2HFcZX2/YEImLBNz5xmDmJTXYEaEGcOdn4Th9W46U0fKI95QQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.8",
+        "@lit-labs/observers": "^2.0.2",
+        "@lit/context": "^1.1.2",
+        "@lit/task": "^1.0.1",
+        "@xstate/store": "^2.5.0",
+        "best-effort-json-parser": "^1.1.2",
+        "lit": "^3.1.4",
+        "marked": "^14.0.0",
+        "picomatch": "^4.0.2",
+        "prismjs": "^1.29.0"
+      }
+    },
+    "node_modules/@getcanary/web/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -3579,6 +3626,44 @@
         "@lezer/lr": "^1.4.0"
       }
     },
+    "node_modules/@lit-labs/observers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.4.tgz",
+      "integrity": "sha512-x95jhDPGb+HtYU3hEdqkcLxb6v2JBP3tcajaiOijs1F/ZmOgRT0pRPn0v+jhhk8mAAbEO12SZJjPCmuysunssQ==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.3.tgz",
+      "integrity": "sha512-Auh37F4S0PZM93HTDfZWs97mmzaQ7M3vnTc9YvxAGyP3UItSK/8Fs0vTOGT+njuvOwbKio/l8Cx/zWL4vkutpQ==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
+    "node_modules/@lit/task": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit/task/-/task-1.0.1.tgz",
+      "integrity": "sha512-fVLDtmwCau8NywnFIXaJxsCZjzaIxnVq+cFRKYC1Y4tA4/0rMTvF6DLZZ2JE51BwzOluaKtgJX8x1QDsQtAaIw==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0"
+      }
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-3.0.0.tgz",
@@ -3909,6 +3994,66 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-tZ9tysUmQpFs2EqWG2+E1gc+opDAhSyZSsgKmFzhnWfkK02YHZhvL5XJXEZDqYy3s1FAKhwjTg8XDxneuBlDZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-ChohLQ39dLwaxQv0jIQB/SavP3TM5K5ENfDTqIdzLkmfs3+JlzSDyQKcJFjTHYcCzQOZVeieeGq8PdqvLJxJxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.1.1.tgz",
+      "integrity": "sha512-H5P6wDoCoAbdsWp0Zx0DxnLUrwTGWGLu/VI1rcN2CyFdY2EGSvPQsbGBMrseKRNuIrJDFtxHHHyjZ7UbzaM9EA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.1.1.tgz",
+      "integrity": "sha512-yJs7tTYbL2MI3HT+ngs9E1BfUbY9M4/YzA0yEM5xBo4Xl8Yu8Qg2xZTOQ1/F6gwvMrjCUFo8EoACs6LRDhtMrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.1.1.tgz",
+      "integrity": "sha512-b7/qPqgIl+lMzkQ8fJt51SfguB396xbIIR+VZ3YrL2tLuyifDJ1wL5mEm+ddmHxJ2Fki340paPcDan9en5OmAw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5104,6 +5249,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
     "node_modules/@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -5529,6 +5679,23 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.12.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xstate/store": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@xstate/store/-/store-2.6.0.tgz",
+      "integrity": "sha512-pHiGIn378yPSCY36f/8iFF1KtKTKpGINqUVJH/dYydzWT+uXc4zKUQ+XUk0qTHchTvBXQ/UivRox2Q19ZnzTjw==",
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "solid-js": "^1.7.6"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -6015,6 +6182,11 @@
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
+    "node_modules/best-effort-json-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/best-effort-json-parser/-/best-effort-json-parser-1.1.2.tgz",
+      "integrity": "sha512-RD7tyk24pNCDwEKFACauR6Lqp5m6BHUrehwyhN/pA8V3QYWq8Y+hk9vHZvKiThZsdEFTaUqN49duVsamgCd8/g=="
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -6485,6 +6657,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-progress/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/cli-progress/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-table3": {
@@ -10338,6 +10539,34 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -10503,6 +10732,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.3.tgz",
+      "integrity": "sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-directive": {
@@ -13106,6 +13346,21 @@
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "peer": true
+    },
+    "node_modules/pagefind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.1.1.tgz",
+      "integrity": "sha512-U2YR0dQN5B2fbIXrLtt/UXNS0yWSSYfePaad1KcBPTi0p+zRtsVjwmoPaMQgTks5DnHNbmDxyJUL5TGaLljK3A==",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.1.1",
+        "@pagefind/darwin-x64": "1.1.1",
+        "@pagefind/linux-arm64": "1.1.1",
+        "@pagefind/linux-x64": "1.1.1",
+        "@pagefind/windows-x64": "1.1.1"
+      }
     },
     "node_modules/param-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@easyops-cn/docusaurus-search-local": "0.45.0",
     "@docusaurus/core": "3.5.2",
     "@docusaurus/plugin-client-redirects": "3.5.2",
     "@docusaurus/preset-classic": "3.5.2",
+    "@getcanary/docusaurus-theme-search-pagefind": "^1.0.2",
+    "@getcanary/web": "^1.0.10",
     "@mdx-js/react": "3.0.1",
     "@scalar/docusaurus": "0.4.115",
     "clsx": "2.1.1",


### PR DESCRIPTION
It use [`Pagefind`](https://pagefind.app/) for local search index, and [`Canary`](https://github.com/fastrepl/canary) for building search UI.

Advantages:

- Pagefind: Best performing local search index. Only load required index chunk while typing.
- Canary: Customizable, styled components with lots of filtering support. Here, we split contents with glob.

To try locally, `npm run build` should be called at least once, because search index is created on production build.

https://github.com/user-attachments/assets/b5dfd466-215f-4e6f-911e-b84d587cc671


